### PR TITLE
优化单元测试速度

### DIFF
--- a/test/NetCorePal.D3Shop.Web.Tests/DemoTests.cs
+++ b/test/NetCorePal.D3Shop.Web.Tests/DemoTests.cs
@@ -8,7 +8,7 @@ using NetCorePal.Extensions.AspNetCore;
 namespace NetCorePal.D3Shop.Web.Tests
 {
     [Collection("web")]
-    public class DemoTests : IClassFixture<MyWebApplicationFactory>
+    public class DemoTests
     {
         private readonly MyWebApplicationFactory _factory;
 

--- a/test/NetCorePal.D3Shop.Web.Tests/Identity/AdminUserRoleIntegrationTests.cs
+++ b/test/NetCorePal.D3Shop.Web.Tests/Identity/AdminUserRoleIntegrationTests.cs
@@ -10,7 +10,7 @@ using NetCorePal.D3Shop.Web.Controllers.Identity;
 namespace NetCorePal.D3Shop.Web.Tests.Identity;
 
 [Collection("web")]
-public class AdminUserRoleIntegrationTests : IClassFixture<MyWebApplicationFactory>
+public class AdminUserRoleIntegrationTests
 {
     private readonly HttpClient _client;
     public AdminUserRoleIntegrationTests(MyWebApplicationFactory factory)

--- a/test/NetCorePal.D3Shop.Web.Tests/Identity/AuthTests.cs
+++ b/test/NetCorePal.D3Shop.Web.Tests/Identity/AuthTests.cs
@@ -9,7 +9,7 @@ using NetCorePal.D3Shop.Web.Helper;
 namespace NetCorePal.D3Shop.Web.Tests.Identity;
 
 [Collection("web")]
-public class AuthTests : IClassFixture<MyWebApplicationFactory>
+public class AuthTests
 {
     private readonly HttpClient _client;
     private readonly AdminUser _testUser = new("Test", "", "", []);

--- a/test/NetCorePal.D3Shop.Web.Tests/MyWebAppCollection.cs
+++ b/test/NetCorePal.D3Shop.Web.Tests/MyWebAppCollection.cs
@@ -1,0 +1,7 @@
+﻿namespace NetCorePal.D3Shop.Web.Tests;
+
+[CollectionDefinition("web")]
+public class MyWebAppCollection : ICollectionFixture<MyWebApplicationFactory>
+{
+    // 此类不需要包含任何代码，其目的仅用于定义集合
+}


### PR DESCRIPTION
修改内容：
1. 定义共享集合以提高资源利用效率。
2. 去掉测试类的 `IClassFixture<MyWebApplicationFactory>` 继承来减少不必要的初始化。

性能对比：
- **未共享资源**:
  - 测试1：1分29秒
  - 测试2：1分19秒
  - 测试3：1分19秒
  - 测试4：1分20秒

- **共享资源**:
  - 测试1：11秒88毫秒
  - 测试2：11秒114毫秒
  - 测试3：11秒722毫秒
  - 测试4：10秒35毫秒
  - 测试5：11秒545毫秒

显著降低了每个测试的执行时间，提高了整体测试效率。

注意事项：
- 这种优化可能引入一些副作用，例如数据污染。因此，需要谨慎处理共享资源，以确保测试环境的独立性和数据完整性。